### PR TITLE
handle spaces

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -23,7 +23,7 @@ exports.parse = function(str) {
   return String(str)
     .split('&')
     .reduce(function(ret, pair){
-      var pair = decodeURIComponent(pair)
+      var pair = decodeURIComponent(pair.replace(/\+/g, ' ')
         , brace = pair.lastIndexOf(']') + 1
         , eql = pair.indexOf('=')
         , key = pair.substr(0, brace || eql)


### PR DESCRIPTION
current:
    $ node -e "require('qs').parse('foo=c++%21%3Dc%2B%2B')"
    { foo: 'c++!=c++' }

patched:
    $ node -e "require('qs').parse('foo=c++%21%3Dc%2B%2B')"
    { foo: 'c  !=c++' }
