### PR TITLE
handle empty string and undefined in qs.parse()

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -20,6 +20,8 @@ exports.version = '0.0.6';
  */
 
 exports.parse = function(str) {
+  if (str === undefined || str === '') return {};
+
   return String(str)
     .split('&')
     .reduce(function(ret, pair){

--- a/test/querystring.test.js
+++ b/test/querystring.test.js
@@ -100,6 +100,14 @@ module.exports = {
   'test duplicates': function(){
     qs.parse('items=bar&items=baz&items=raz')
       .should.eql({ items: ['bar', 'baz', 'raz'] });
+  },
+
+  'test empty': function(){
+    qs.parse('')
+      .should.eql({});
+
+    qs.parse(undefined)
+      .should.eql({});
   }
   
   // 'test complex': function(){


### PR DESCRIPTION
With Node 0.4.2 and qs 0.0.6 I get the following behavior:

```
> var qs = require('qs');
> qs.parse('');
{ '': '' }
> qs.parse(undefined);
{ undefined: '' }
```

Node 0.4 doesn't include a `query` property in the object returned by `url.parse(str)` if there is no query string in the url, so `qs.parse(url.parse(str).query)` is essentially the same as `qs.parse(undefined)` for those cases.

Running benchmark.js, the numbers don't seem to be affected by the change.
