### PR TITLE
Fix for Unscoped Properties

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -46,7 +46,7 @@ exports.parse = function(str) {
           var part = parts.shift();
 
           // end
-          if (!part) {
+          if (!part && parent) {
             if (Array.isArray(parent[key])) {
               parent[key].push(val);
             } else if ('object' == typeof parent[key]) {
@@ -64,6 +64,9 @@ exports.parse = function(str) {
           } else if (~part.indexOf(']')) {
             part = part.substr(0, part.length - 1);
             parse(obj[part] = obj[part] || {}, parts, obj, part);
+          // unscoped prop
+          } else if (!part && !parent) {
+            parse(obj, parts, obj);
           // key
           } else {
             parse(obj[part] = obj[part] || {}, parts, obj, part);

--- a/test/querystring.test.js
+++ b/test/querystring.test.js
@@ -50,6 +50,9 @@ module.exports = {
         , chs: '250x100'
         , chl: 'Hello|World'
       });
+      
+    qs.parse('[foo]=bar')
+      .should.eql({ foo: 'bar' });
   },
   
   'test nesting': function(){


### PR DESCRIPTION
I took a stab at this: 

Updated parse method to only enter end condition if parent is present. Added un-scoped property condition that will be entered if a part and parent doesn't exist.  Essentially re-executes the parse condition with the same object but using next part, setting obj as the parent if the part is empty.
