### PR TITLE
Add qs.stringify(object)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,10 +6,22 @@
 
     $ npm install qs
 
+
 ## Examples
 
     require('qs').parse('user[name][first]=tj&user[email]=tj');
     // => { user: { name: { first: 'tj' }, email: 'tj' } }
+
+## Testing
+
+Update git submodules:
+
+    $ git submodule init
+    $ git submodule update
+
+and execute:
+
+    $ make test
 
 ## License 
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -81,6 +81,70 @@ exports.parse = function(str) {
 };
 
 /**
+ * Turn the given `obj` into a query string
+ *
+ * @param {Object} obj
+ * @return {String}
+ * @api public
+ */
+
+exports.stringify = function stringify(obj) {
+  return _stringify(obj, null);
+};
+
+/**
+ * Private function to decompose nested objects for public function `stringify`
+ * Adapted from ruby's Rack::Utils#build_nested_query # https://github.com/rack/rack/blob/master/lib/rack/utils.rb
+ * 
+ * @param {Object} value
+ * @param {String} prefix
+ * @return {String}
+ * @api private
+ */
+function _stringify(value, prefix) {
+  var result = [];
+  if ( is('Array', value) ) {
+    for (var i = 0; i < value.length; i++) {
+      result.push( _stringify(value[i], prefix + '[]') );
+    }
+    return result.join("&");
+  } else if ( is('Object', value) ) {
+    var k,v;
+    for (var i in value) {
+      if ( value.hasOwnProperty(i) ) {
+        k = i;
+        v = value[i];
+        result.push( _stringify(v, prefix ? prefix + '[' + encodeURIComponent(k) + ']' : encodeURIComponent(k) ) );
+      }
+    }
+    return result.join("&");
+  } else if ( is('String', value) ) {
+    if (typeof prefix === 'undefined') {
+      throw new Error("Value must be a hash");
+    }
+    return prefix + '=' + encodeURIComponent(value);
+  } else {
+    return prefix;
+  }
+}
+
+/**
+ * Determine class of the given object
+ * Possible values for type are 'String','Object','Array','Number',
+ * 'Date', 'Error', 'Function', 'Boolean' and 'RegExp'
+ * Taken from http://bonsaiden.github.com/JavaScript-Garden/#types.typeof
+ * 
+ * @param {String} type
+ * @param {Object} obj
+ * @return {Boolean}
+ * @api private
+ */
+function is(type, obj) {
+    var clas = Object.prototype.toString.call(obj).slice(8, -1);
+    return obj !== undefined && obj !== null && clas === type;
+}
+
+/**
  * Set `obj`'s `key` to `val` respecting
  * the weird and wonderful syntax of a qs,
  * where "foo=bar&foo=baz" becomes an array.

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -89,7 +89,7 @@ exports.parse = function(str) {
  */
 
 exports.stringify = function stringify(obj) {
-  return _stringify(obj, null);
+  return _stringify(obj);
 };
 
 /**
@@ -104,6 +104,9 @@ exports.stringify = function stringify(obj) {
 function _stringify(value, prefix) {
   var result = [];
   if ( is('Array', value) ) {
+    if (typeof prefix === 'undefined' ) {
+      throw new Error("Value must be a hash");
+    }
     for (var i = 0; i < value.length; i++) {
       result.push( _stringify(value[i], prefix + '[]') );
     }

--- a/test/querystring.stringify.test.js
+++ b/test/querystring.stringify.test.js
@@ -42,9 +42,26 @@ var qs = require('../')
       {query_string: 'x[y][][z]=1&x[y][][z]=2', parsed: {'x' : {'y' : [{'z' : '1'}, {'z' : '2'}]}}},
       {query_string: 'x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3', parsed: {'x' : {'y' : [{'z' : '1', 'w' : 'a'}, {'z' : '2', 'w' : '3'}]}}},
       {query_string: 'user[name][first]=tj&user[name][last]=holowaychuk', parsed: { user: { name: { first: 'tj', last: 'holowaychuk' }}}}
+    ],
+    'errors': [
+      {parsed: 'foo=bar',     message: 'Value must be a hash'},
+      {parsed: ['foo','bar'], message: 'Value must be a hash'}
     ]
   };
   
+
+// Assert error
+function err(fn, msg){
+  var err;
+  try {
+    fn();
+  } catch (e) {
+    should.equal(e.message, msg);
+    return;
+  }
+  throw new Error('no exception thrown, expected "' + msg + '"');
+}
+
 module.exports = {
   'test basics': function() {
     var query_string, parsed;
@@ -68,6 +85,14 @@ module.exports = {
       query_string = query_string_identities['nested'][i].query_string;
       parsed       = query_string_identities['nested'][i].parsed;
       qs.stringify(parsed).should.eql(query_string);
+    }
+  },
+  'test errors': function() {
+    var parsed, message;
+    for (var i = 0; i < query_string_identities['errors'].length; i++) {
+      message      = query_string_identities['errors'][i].message;
+      parsed       = query_string_identities['errors'][i].parsed;
+      err( function() {qs.stringify(parsed)}, message );
     }
   }
 };

--- a/test/querystring.stringify.test.js
+++ b/test/querystring.stringify.test.js
@@ -1,0 +1,73 @@
+
+/**
+ * Module dependencies.
+ */
+
+var qs = require('../')
+  , should = require('should')
+  , query_string_identities = {
+    'basics': [
+      {query_string: 'foo=bar', parsed: {'foo' : 'bar'}},
+      {query_string: 'foo=%22bar%22', parsed: {'foo' : '\"bar\"'}},
+      {query_string: 'foo=', parsed: {'foo': ''}},
+      {query_string: 'foo=1&bar=2', parsed: {'foo' : '1', 'bar' : '2'}},
+      {query_string: 'my%20weird%20field=q1!2%22\'w%245%267%2Fz8)%3F', parsed: {'my weird field': "q1!2\"'w$5&7/z8)?"}},
+      {query_string: 'foo%3Dbaz=bar', parsed: {'foo=baz': 'bar'}},
+      {query_string: 'foo=bar&bar=baz', parsed: {foo: 'bar', bar: 'baz'}}
+    ],
+    'escaping': [
+      {query_string: 'foo=foo%20bar', parsed: {foo: 'foo bar'}},
+      {query_string: 'cht=p3&chd=t%3A60%2C40&chs=250x100&chl=Hello%7CWorld', parsed: {
+          cht: 'p3'
+        , chd: 't:60,40'
+        , chs: '250x100'
+        , chl: 'Hello|World'
+      }}
+    ],
+    'nested': [
+      {query_string: 'foo[]=bar&foo[]=quux', parsed: {'foo' : ['bar', 'quux']}},
+      {query_string: 'foo[]=bar', parsed: {foo: ['bar']}},
+      {query_string: 'foo[]=1&foo[]=2', parsed: {'foo' : ['1', '2']}},
+      {query_string: 'foo=bar&baz[]=1&baz[]=2&baz[]=3', parsed: {'foo' : 'bar', 'baz' : ['1', '2', '3']}},
+      {query_string: 'foo[]=bar&baz[]=1&baz[]=2&baz[]=3', parsed: {'foo' : ['bar'], 'baz' : ['1', '2', '3']}},
+      {query_string: 'x[y][z]=1', parsed: {'x' : {'y' : {'z' : '1'}}}},
+      {query_string: 'x[y][z][]=1', parsed: {'x' : {'y' : {'z' : ['1']}}}},
+      {query_string: 'x[y][z]=2', parsed: {'x' : {'y' : {'z' : '2'}}}},
+      {query_string: 'x[y][z][]=1&x[y][z][]=2', parsed: {'x' : {'y' : {'z' : ['1', '2']}}}},
+      {query_string: 'x[y][][z]=1', parsed: {'x' : {'y' : [{'z' : '1'}]}}},
+      {query_string: 'x[y][][z][]=1', parsed: {'x' : {'y' : [{'z' : ['1']}]}}},
+      {query_string: 'x[y][][z]=1&x[y][][w]=2', parsed: {'x' : {'y' : [{'z' : '1', 'w' : '2'}]}}},
+      {query_string: 'x[y][][v][w]=1', parsed: {'x' : {'y' : [{'v' : {'w' : '1'}}]}}},
+      {query_string: 'x[y][][z]=1&x[y][][v][w]=2', parsed: {'x' : {'y' : [{'z' : '1', 'v' : {'w' : '2'}}]}}},
+      {query_string: 'x[y][][z]=1&x[y][][z]=2', parsed: {'x' : {'y' : [{'z' : '1'}, {'z' : '2'}]}}},
+      {query_string: 'x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3', parsed: {'x' : {'y' : [{'z' : '1', 'w' : 'a'}, {'z' : '2', 'w' : '3'}]}}},
+      {query_string: 'user[name][first]=tj&user[name][last]=holowaychuk', parsed: { user: { name: { first: 'tj', last: 'holowaychuk' }}}}
+    ]
+  };
+  
+module.exports = {
+  'test basics': function() {
+    var query_string, parsed;
+    for (var i = 0; i < query_string_identities['basics'].length; i++) {
+      query_string = query_string_identities['basics'][i].query_string;
+      parsed       = query_string_identities['basics'][i].parsed;
+      qs.stringify(parsed).should.eql(query_string);
+    }
+  },
+  'test escaping': function() {
+    var query_string, parsed;
+    for (var i = 0; i < query_string_identities['escaping'].length; i++) {
+      query_string = query_string_identities['escaping'][i].query_string;
+      parsed       = query_string_identities['escaping'][i].parsed;
+      qs.stringify(parsed).should.eql(query_string);
+    }
+  },
+  'test nested': function() {
+    var query_string, parsed;
+    for (var i = 0; i < query_string_identities['nested'].length; i++) {
+      query_string = query_string_identities['nested'][i].query_string;
+      parsed       = query_string_identities['nested'][i].parsed;
+      qs.stringify(parsed).should.eql(query_string);
+    }
+  }
+};


### PR DESCRIPTION
I used a lot of the tests for qs.parse as a starting point, but they're not necessarily reversible (because when turning the object into a query string, the keys and values each need to get escaped) so I didn't use all of them verbatim.

The function itself is adapted from Ruby's Rack::Utils query parser/builder, and I took many of the tests from there as well.
