### PR TITLE
This adds some more sophisticated array-or-object parsing

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -37,3 +37,12 @@ console.log(obj)
 
 var obj = qs.parse('user[name][first]=tj&user[name][first]=TJ');
 console.log(obj)
+
+var obj = qs.parse('user[0]=tj&user[1]=TJ');
+console.log(obj)
+
+var obj = qs.parse('user[0]=tj&user[]=TJ');
+console.log(obj)
+
+var obj = qs.parse('user[0]=tj&user[foo]=TJ');
+console.log(obj)

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -27,6 +27,15 @@ var toString = Object.prototype.toString;
 
 exports.parse = function(str){
   if (str == undefined || str == '') return {};
+  var notint = /[^0-9]/
+
+  function promote(parent, key) {
+    if(parent[key].length == 0) return parent[key] = {};
+    var t = {};
+    for(var i in parent[key]) t[i] = parent[key][i];
+    parent[key] = t;
+    return t;
+  }
 
   return String(str)
     .split('&')
@@ -47,13 +56,6 @@ exports.parse = function(str){
         var parts = key.split('[')
           , len = parts.length
           , last = len - 1;
-
-        function promote(parent, key) {
-          var t = {};
-          for(var i in parent[key]) t[i] = parent[key][i];
-          parent[key] = t;
-          return t;
-        }
 
         function parse(parts, parent, key) {
           var part = parts.shift();
@@ -83,11 +85,11 @@ exports.parse = function(str){
             // prop
             } else if (~part.indexOf(']')) {
               part = part.substr(0, part.length - 1);
-              if(!/^\d+$/.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+              if(notint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
               parse(parts, obj, part);
             // key
             } else {
-              if(!/^\d*$/.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+              if(notint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
               parse(parts, obj, part);
             }
           }
@@ -96,7 +98,7 @@ exports.parse = function(str){
         parse(parts, parent, 'base');
       // optimize
       } else {
-        if(!/^\d*$/.test(key) && Array.isArray(parent.base)) {
+        if(notint.test(key) && Array.isArray(parent.base)) {
           var t = {};
           for(var k in parent.base) t[k] = parent.base[k];
           parent.base = t;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -37,7 +37,7 @@ exports.parse = function(str){
         , key = pair.substr(0, brace || eql)
         , val = pair.substr(brace || eql, pair.length)
         , val = val.substr(val.indexOf('=') + 1, val.length)
-        , obj = ret;
+        , parent = ret;
 
       // ?foo
       if ('' == key) key = pair, val = '';
@@ -48,7 +48,14 @@ exports.parse = function(str){
           , len = parts.length
           , last = len - 1;
 
-        function parse(obj, parts, parent, key) {
+        function promote(parent, key) {
+          var t = {};
+          for(var i in parent[key]) t[i] = parent[key][i];
+          parent[key] = t;
+          return t;
+        }
+
+        function parse(parts, parent, key) {
           var part = parts.shift();
 
           // end
@@ -57,33 +64,48 @@ exports.parse = function(str){
               parent[key].push(val);
             } else if ('object' == typeof parent[key]) {
               parent[key] = val;
+            } else if ('undefined' == typeof parent[key]) {
+              parent[key] = val;
             } else {
               parent[key] = [parent[key], val];
             }
           // array
-          } else if (']' == part) {
-            obj = parent[key] = Array.isArray(parent[key])
-              ? parent[key]
-              : [];
-            if ('' != val) obj.push(val);
-          // prop
-          } else if (~part.indexOf(']')) {
-            part = part.substr(0, part.length - 1);
-            parse(obj[part] = obj[part] || {}, parts, obj, part);
-          // key
           } else {
-            parse(obj[part] = obj[part] || {}, parts, obj, part);
+            obj = parent[key] = parent[key] || [];
+            if (']' == part) {
+              if(Array.isArray(obj)) {
+                if ('' != val) obj.push(val);
+              } else if ('object' == typeof obj) {
+                obj[Object.keys(obj).length] = val;
+              } else {
+                obj = parent[key] = [parent[key], val];
+              }
+            // prop
+            } else if (~part.indexOf(']')) {
+              part = part.substr(0, part.length - 1);
+              if(!/^\d+$/.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+              parse(parts, obj, part);
+            // key
+            } else {
+              if(!/^\d*$/.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+              parse(parts, obj, part);
+            }
           }
         }
 
-        parse(obj, parts);
+        parse(parts, parent, 'base');
       // optimize
       } else {
-        set(obj, key, val);
+        if(!/^\d*$/.test(key) && Array.isArray(parent.base)) {
+          var t = {};
+          for(var k in parent.base) t[k] = parent.base[k];
+          parent.base = t;
+        }
+        set(parent.base, key, val);
       }
 
       return ret;
-    }, {});
+    }, {base: []}).base;
 };
 
 /**

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -117,6 +117,14 @@ module.exports = {
     qs.parse('').should.eql({});
     qs.parse(undefined).should.eql({});
     qs.parse(null).should.eql({});
+  },
+
+  'test arrays with indexes': function(){
+    qs.parse('foo[0]=bar&foo[1]=baz').should.eql({"foo":["bar","baz"]});
+  },
+
+  'test arrays becoming objects': function(){
+    qs.parse('foo[0]=bar&foo[bad]=baz').should.eql({"foo":{"0":"bar","bad":"baz"}});
   }
   
   // 'test complex': function(){


### PR DESCRIPTION
  foo[1]=bar&foo[baz]=blat

becomes

  {foo: {"1": "bar", "baz": "blat"}}

but

  foo[0]=bar&foo[1]=baz

becomes

  {foo: ["bar", "baz"]}

Empty property becomes array becomes object, depending on what keys are used.

Performance implications: A hair slower -- my testcase says 3.7s vs 4.4s.
