### PR TITLE
Fixed erroneous keys being returned

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -112,7 +112,7 @@ exports.parse = function(str){
       }
 
       return ret;
-    }, {base: []}).base;
+    }, {base: {}}).base;
 };
 
 /**

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -129,6 +129,11 @@ module.exports = {
   'test arrays becoming objects': function(){
     qs.parse('foo[0]=bar&foo[bad]=baz').should.eql({ foo: { 0: "bar", bad: "baz" }});
     qs.parse('foo[bad]=baz&foo[0]=bar').should.eql({ foo: { 0: "bar", bad: "baz" }});
+  },
+
+  'test bleed-through of Array native methods': function(){
+    Array.prototype.testFunction = function () {};
+    qs.parse('foo=bar').should.eql({ foo: 'bar' });
   }
   
   // 'test complex': function(){

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -131,8 +131,9 @@ module.exports = {
     qs.parse('foo[bad]=baz&foo[0]=bar').should.eql({ foo: { 0: "bar", bad: "baz" }});
   },
 
-  'test bleed-through of Array native methods': function(){
-    Array.prototype.testFunction = function () {};
+  'test bleed-through of Array native properties/methods': function(){
+    Array.prototype.protoProperty = true;
+    Array.prototype.protoFunction = function () {};
     qs.parse('foo=bar').should.eql({ foo: 'bar' });
   }
   


### PR DESCRIPTION
Prototype methods on the Array native would be returned as if they
were part of query string data.

Switching the initial value to an Object literal rather than an Array literal resolves the issue.

make test:
 100% 13 tests
