### PR TITLE
unescape fallback for malformed uri components

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -47,7 +47,7 @@ exports.parse = function(str){
       try{ 
         pair = decodeURIComponent(pair.replace(/\+/g, ' '));
       } catch(e) {
-        // ignore
+        pair = unescape(pair.replace(/\+/g, ' '));
       }
 
       var eql = pair.indexOf('=')

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -141,6 +141,10 @@ module.exports = {
     qs.parse('{%:%}').should.eql({ '{%:%}': '' });
     qs.parse('foo=%:%}').should.eql({ 'foo': '%:%}' });
     qs.parse('foo=%:%}%20').should.eql({ 'foo': '%:%} ' });
+  },
+
+  'test unescaping of non-utf8 encoded data': function(){
+    qs.parse('foo=%E4%20bar').should.eql({ 'foo': String.fromCharCode('228') + ' bar' });
   }
 
   // 'test complex': function(){

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -140,8 +140,9 @@ module.exports = {
   'test malformed uri': function(){
     qs.parse('{%:%}').should.eql({ '{%:%}': '' });
     qs.parse('foo=%:%}').should.eql({ 'foo': '%:%}' });
+    qs.parse('foo=%:%}%20').should.eql({ 'foo': '%:%} ' });
   }
-  
+
   // 'test complex': function(){
   //   qs.parse('users[][name][first]=tj&users[foo]=bar')
   //     .should.eql({


### PR DESCRIPTION
instead of just ignoring wrong encoded uri components, we should at least unescape them with the default javascript unescape function, which doesn't break on malformed encodings.

this fixes issues in a messed up iso-8859-1 environment.
