### PR TITLE
Unifies multipart, json, and form-urlencoded in the bodyParser() middleware

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -94,7 +94,6 @@ function parse_obj(obj){
 }
 
 function parse_str(str){
-  if (null == str || '' == str) return {};
 
   return String(str)
     .split('&')
@@ -128,6 +127,8 @@ function parse_str(str){
  */
 
 exports.parse = function(str){
+  if (null == str || '' == str) return {};
+
   if(typeof str == "object"){
     return parse_obj(str);
   } else {

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -22,29 +22,84 @@ var toString = Object.prototype.toString;
 
 var notint = /[^0-9]/;
 
-/**
- * Parse the given query `str`, returning an object.
- *
- * @param {String} str
- * @return {Object}
- * @api public
- */
+function promote(parent, key) {
+  if (parent[key].length == 0) return parent[key] = {};
+  var t = {};
+  for (var i in parent[key]) t[i] = parent[key][i];
+  parent[key] = t;
+  return t;
+}
 
-exports.parse = function(str){
-  if (null == str || '' == str) return {};
-
-  function promote(parent, key) {
-    if (parent[key].length == 0) return parent[key] = {};
-    var t = {};
-    for (var i in parent[key]) t[i] = parent[key][i];
-    parent[key] = t;
-    return t;
+function parse(parts, parent, key, val) {
+  var part = parts.shift();
+  // end
+  if (!part) {
+    if (Array.isArray(parent[key])) {
+      parent[key].push(val);
+    } else if ('object' == typeof parent[key]) {
+      parent[key] = val;
+    } else if ('undefined' == typeof parent[key]) {
+      parent[key] = val;
+    } else {
+      parent[key] = [parent[key], val];
+    }
+    // array
+  } else {
+    var obj = parent[key] = parent[key] || [];
+    if (']' == part) {
+      if (Array.isArray(obj)) {
+        if ('' != val) obj.push(val);
+      } else if ('object' == typeof obj) {
+        obj[Object.keys(obj).length] = val;
+      } else {
+        obj = parent[key] = [parent[key], val];
+      }
+      // prop
+    } else if (~part.indexOf(']')) {
+      part = part.substr(0, part.length - 1);
+      if(notint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+      parse(parts, obj, part, val);
+      // key
+    } else {
+      if(notint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+      parse(parts, obj, part, val);
+    }
   }
+}
+
+function merge(parent, key, val){
+  if (~key.indexOf(']')) {
+    var parts = key.split('[')
+      , len = parts.length
+      , last = len - 1;
+    parse(parts, parent, 'base', val);
+    // optimize
+  } else {
+    if (notint.test(key) && Array.isArray(parent.base)) {
+      var t = {};
+      for(var k in parent.base) t[k] = parent.base[k];
+      parent.base = t;
+    }
+    set(parent.base, key, val);
+  }
+  return parent;
+}
+
+function parse_obj(obj){
+  var ret = {base:{}};
+  Object.keys(obj).forEach(function(name){
+    merge(ret, name, obj[name]);
+  });
+  return ret.base;
+}
+
+function parse_str(str){
+  if (null == str || '' == str) return {};
 
   return String(str)
     .split('&')
     .reduce(function(ret, pair){
-      try{ 
+      try{
         pair = decodeURIComponent(pair.replace(/\+/g, ' '));
       } catch(e) {
         // ignore
@@ -54,69 +109,30 @@ exports.parse = function(str){
         , brace = lastBraceInKey(pair)
         , key = pair.substr(0, brace || eql)
         , val = pair.substr(brace || eql, pair.length)
-        , val = val.substr(val.indexOf('=') + 1, val.length)
-        , parent = ret;
+	, val = val.substr(val.indexOf('=') + 1, val.length);
 
       // ?foo
       if ('' == key) key = pair, val = '';
 
-      // nested
-      if (~key.indexOf(']')) {
-        var parts = key.split('[')
-          , len = parts.length
-          , last = len - 1;
+      return merge(ret, key, val);
 
-        function parse(parts, parent, key) {
-          var part = parts.shift();
-
-          // end
-          if (!part) {
-            if (Array.isArray(parent[key])) {
-              parent[key].push(val);
-            } else if ('object' == typeof parent[key]) {
-              parent[key] = val;
-            } else if ('undefined' == typeof parent[key]) {
-              parent[key] = val;
-            } else {
-              parent[key] = [parent[key], val];
-            }
-          // array
-          } else {
-            var obj = parent[key] = parent[key] || [];
-            if (']' == part) {
-              if (Array.isArray(obj)) {
-                if ('' != val) obj.push(val);
-              } else if ('object' == typeof obj) {
-                obj[Object.keys(obj).length] = val;
-              } else {
-                obj = parent[key] = [parent[key], val];
-              }
-            // prop
-            } else if (~part.indexOf(']')) {
-              part = part.substr(0, part.length - 1);
-              if(notint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
-              parse(parts, obj, part);
-            // key
-            } else {
-              if(notint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
-              parse(parts, obj, part);
-            }
-          }
-        }
-
-        parse(parts, parent, 'base');
-      // optimize
-      } else {
-        if (notint.test(key) && Array.isArray(parent.base)) {
-          var t = {};
-          for(var k in parent.base) t[k] = parent.base[k];
-          parent.base = t;
-        }
-        set(parent.base, key, val);
-      }
-
-      return ret;
     }, {base: {}}).base;
+}
+
+/**
+ * Parse the given query `str` or `obj`, returning an object.
+ *
+ * @param {String} str | {Object} obj
+ * @return {Object}
+ * @api public
+ */
+
+exports.parse = function(str){
+  if(typeof str == "object"){
+    return parse_obj(str);
+  } else {
+    return parse_str(str);
+  }
 };
 
 /**


### PR DESCRIPTION
http://tjholowaychuk.com/post/12943975936/connect-1-8-0-multipart-support

Unifies multipart, json, and x-www-form-urlencoded parsing in the bodyParser() middleware is exactlly what I want. But something is missing, still.

for example:

``` bash
$ curl http://127.0.0.1:3000/test.form -F content[1]=@test/clear.gif -F content[0]="text0" -F content[2]="test2" -F content[]="test3"
 {"content":["text0",null,"test2","test3"],"content[1]":{...}}
```

But it should be (keep same as x-www-form-urlencoded parsing does)

``` bash
$ curl http://127.0.0.1:3000/test.form -F content[1]=@test/clear.gif -F content[0]="text0" -F content[2]="test2" -F content[]="test3"
 {"content":["text0",{...},"test2","test3"]}
```

After a half-day hacking in the code. I found the nest-name parse was in the `qs` module. It shoud been _reuse_ in multipart parsing process as well.

so I refactor querystring.js(just move out functions etc.), make qs.parse can accept an object as input param.

After that, the bodyParser() middleware could reuse the nest-name parse logic in multipart, just like this:

``` javascript
/**
 * Parse multipart/form-data.
 *
 * TODO: make multiple support optional
 * TODO: revisit "error" flag if it's a formidable bug
 */
exports.parse['multipart/form-data'] = function(req, options, fn){
  var form = new formidable.IncomingForm
    , data = {}
    , done;

  Object.keys(options).forEach(function(key){
    form[key] = options[key];
  });

  function collect(name, val){
    if (Array.isArray(data[name])) {
      data[name].push(val);
    } else if (data[name]) {
      data[name] = [data[name], val];
    } else {
      data[name] = val;
    }
  }

  form.on('field', collect);

  form.on('file', collect);

  form.on('error', function(err){
    fn(err);
    done = true;
  });

  form.on('end', function(){
    if (done) return;
    try {
      req.body = qs.parse(data); // using the same nest-name mapping logic
      fn();
    } catch (err) {
      fn(err);
    }
  });

  form.parse(req);
};
```

BTW. I cannot find the latest version of bodyParser.js in github, so I just paste the code here.
