### PR TITLE
Handle partially parsed objects (w/ querystrings as keys)

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -35,15 +35,7 @@ function parse(parts, parent, key, val) {
   var part = parts.shift();
   // end
   if (!part) {
-    if (Array.isArray(parent[key])) {
-      parent[key].push(val);
-    } else if ('object' == typeof parent[key]) {
-      parent[key] = val;
-    } else if ('undefined' == typeof parent[key]) {
-      parent[key] = val;
-    } else {
-      parent[key] = [parent[key], val];
-    }
+    set(parent, key, val);
     // array
   } else {
     var obj = parent[key] = parent[key] || [];
@@ -95,8 +87,8 @@ function merge(parent, key, val){
  * Parse the given obj.
  */
 
-function parseObject(obj){
-  var ret = { base: {} };
+function parseObject(obj, base){
+  var ret = { base: base || {} };
   Object.keys(obj).forEach(function(name){
     merge(ret, name, obj[name]);
   });
@@ -232,10 +224,13 @@ function stringifyObject(obj, prefix) {
 
 function set(obj, key, val) {
   var v = obj[key];
-  if (undefined === v) {
+  if ('undefined' == typeof v) {
     obj[key] = val;
   } else if (Array.isArray(v)) {
     v.push(val);
+  } else if (('object' == typeof v) && ('[object Object]' == toString.call(val))) {
+    // partially parsed object
+    parseObject(val, v);
   } else {
     obj[key] = [v, val];
   }

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -227,7 +227,7 @@ function set(obj, key, val) {
   if ('undefined' == typeof v) {
     obj[key] = val;
   } else if (Array.isArray(v)) {
-    v.push(val);
+    obj[key] = v.concat(val);
   } else if (('object' == typeof v) && ('[object Object]' == toString.call(val))) {
     // partially parsed object
     parseObject(val, v);

--- a/test/parse.js
+++ b/test/parse.js
@@ -145,6 +145,12 @@ module.exports = {
     qs.parse({ 'foo[0]': 'bar', 'foo[1]': 'baz' })
       .should.eql({ foo: ['bar', 'baz'] });
 
+    qs.parse({ 'foo[items]': [], foo: { items: ['bar'] } })
+      .should.eql({ foo: { items: ['bar'] } })
+
+    qs.parse({ foo: { items: ['bar'] }, 'foo[items]': [] })
+      .should.eql({ foo: { items: ['bar'] } })
+
     qs.parse({ 'foo[base64]': 'RAWR', 'foo[64base]': 'RAWR' })
       .should.eql({ foo: { base64: 'RAWR', '64base': 'RAWR' } });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -139,6 +139,23 @@ module.exports = {
   'test malformed uri': function(){
     qs.parse('{%:%}').should.eql({ '{%:%}': '' });
     qs.parse('foo=%:%}').should.eql({ 'foo': '%:%}' });
+  },
+
+  'test partially parsed objects': function(){
+    qs.parse({ 'foo[0]': 'bar', 'foo[1]': 'baz' })
+      .should.eql({ foo: ['bar', 'baz'] });
+
+    qs.parse({ 'foo[base64]': 'RAWR', 'foo[64base]': 'RAWR' })
+      .should.eql({ foo: { base64: 'RAWR', '64base': 'RAWR' } });
+
+    qs.parse({ 'user[name][first]': ['tj', 'TJ'] })
+      .should.eql({ user: { name: { first: ['tj', 'TJ'] } } });
+
+    qs.parse({ 'user[name]': { first: 'tj' }, 'user': { name: { last: 'holowaychuk' } } })
+      .should.eql({ user: { name: { first: 'tj', last: 'holowaychuk' } } });
+
+    qs.parse({ 'user': { name: { last: 'holowaychuk' } }, 'user[name]': { first: 'tj' } })
+      .should.eql({ user: { name: { last: 'holowaychuk', first: 'tj' } } });
   }
   
   // 'test complex': function(){


### PR DESCRIPTION
## tl;dr
- { 'foo[bar]': { qux: 0 }, 'foo': { baz: 1 } } => { foo: { bar: { qux: 0 }, baz: 1 } }
- previously this would work in some cases, this fix handles most cases properly
- allows for handling of pre-parsed multipart forms from felixge/node-formidable
- only added a few lines plus tests, all tests pass
## Why?

For multipart forms, particularly from [node-formidable](https://github.com/felixge/node-formidable). This particular use case is important:

**We can use mimetypes to partially parse data from node-formidable parts, before using qs to reassemble**

``` js

// Raw POST body:
//
// --xxxxxxxx
// Content-Disposition: form-data; name="foo"
// Content-Type: application/json
// 
// {"bar": "baz"}
// --xxxxxxxx
// Content-Disposition: form-data; name="foo[qux]"
// Content-Type: image/jpeg
// 
// (... image data ...)
// --xxxxxxxx--

// Simplified example:

> console.log(qs.parse({
>   foo: JSON.parse("{\"bar\": \"baz\"}")
> , 'foo[qux]': [object Object] // JPEG data in Formidable.File object
> }));
>
{
  foo: {
    bar: "baz",
    qux: [object Object] // JPEG data in Formidable.File object
  }
}
```
## Does we really need this?

Yes. The [RestKit iOS framework](https://github.com/RestKit/RestKit) (among others) can send multipart forms containing both `application/json` and attachment (ie. `image/jpeg`) data. Properly merging the parts back into a single params object is crucial. The ExpressJS body-parser got us most of the way there—although we did have to override `handlePart()` so we could parse the JSON based on the mimetype.

The final piece of the puzzle is getting qs to reassemble the parts from the querystring paths as expected. As I mentioned in the commit message, qs was doing this properly in some cases, but not all (depending on part order from node-formidable, which is apparently non-deterministic). This fix should handle most cases as expected.
