### PR TITLE
Added a numeric index in array stringify to preserve reversability

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -192,7 +192,7 @@ function stringifyArray(arr, prefix) {
   var ret = [];
   if (!prefix) throw new TypeError('stringify expects an object');
   for (var i = 0; i < arr.length; i++) {
-    ret.push(stringify(arr[i], prefix + '[]'));
+    ret.push(stringify(arr[i], prefix + '['+i+']'));
   }
   return ret.join('&');
 }


### PR DESCRIPTION
When stringifying this data structure,

``` js
{
    name: "answer #2",
    choices: [
        {propositionid:'4f47bfe1bc9dd1432900000a', dispo: 'yes'},
            {propositionid:'4f47bfe1bc9dd14329000009', dispo: 'no'}
    ]
}
```

one gets

``` js
name=answer%20%232&choices[][propositionid]=4f47bfe1bc9dd1432900000a&choices[][dispo]=yes&choices[][propositionid]=4f47bfe1bc9dd14329000009&choices[][dispo]=no
```

As you can notice, there is an ambiguity that prevents the parser from building the data-structure back. When generated this way

``` js
name=answer%20%232&choices[0][propositionid]=4f47bfe1bc9dd1432900000a&choices[0][dispo]=yes&choices[1][propositionid]=4f47bfe1bc9dd14329000009&choices[1][dispo]=no
```

Then, everything is alright again. Here is a tentative to fix it.
