### PR TITLE
Custom Delimiter Support

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -18,10 +18,11 @@ exports.version = '0.4.2';
 var toString = Object.prototype.toString;
 
 /**
- * Cache non-integer test regexp.
+ * Cache non-integer and custom delimiter test regexp.
  */
 
-var isint = /^[0-9]+$/;
+var isint = /^[0-9]+$/
+  , isdelim = /^[^\?&#=\[\]]/;
 
 function promote(parent, key) {
   if (parent[key].length == 0) return parent[key] = {};
@@ -72,11 +73,28 @@ function parse(parts, parent, key, val) {
  * Merge parent key/val pair.
  */
 
-function merge(parent, key, val){
+function merge(parent, key, val, del){
   if (~key.indexOf(']')) {
     var parts = key.split('[')
       , len = parts.length
       , last = len - 1;
+    if (del) {
+        var keydel = ']' + del;
+        for ( var idx = 0; idx < parts.length; idx++ ) {
+            var part = parts[idx]
+              , args = [idx, 1]
+              , k = part.split(keydel, 2);
+            switch (true) {
+                case k.length > 1:
+                    args.push(k[0]);
+                    part = k[1];
+                case idx === 0:
+                    args = args.concat(part.split(del));
+                    idx += args.length - 3;
+                    parts.splice.apply(parts, args);
+            }
+        }
+    }
     parse(parts, parent, 'base', val);
     // optimize
   } else {
@@ -85,7 +103,11 @@ function merge(parent, key, val){
       for (var k in parent.base) t[k] = parent.base[k];
       parent.base = t;
     }
-    set(parent.base, key, val);
+    var parts = key.split(del);
+    if (parts.length > 1)
+        parse(parts, parent, 'base', val);
+    else
+        set(parent.base, key, val);
   }
 
   return parent;
@@ -95,10 +117,10 @@ function merge(parent, key, val){
  * Parse the given obj.
  */
 
-function parseObject(obj){
+function parseObject(obj, del){
   var ret = { base: {} };
   Object.keys(obj).forEach(function(name){
-    merge(ret, name, obj[name]);
+    merge(ret, name, obj[name], del);
   });
   return ret.base;
 }
@@ -107,7 +129,7 @@ function parseObject(obj){
  * Parse the given str.
  */
 
-function parseString(str){
+function parseString(str, del){
   return String(str)
     .split('&')
     .reduce(function(ret, pair){
@@ -126,7 +148,7 @@ function parseString(str){
       // ?foo
       if ('' == key) key = pair, val = '';
 
-      return merge(ret, key, val);
+      return merge(ret, key, val, del);
     }, { base: {} }).base;
 }
 
@@ -138,11 +160,12 @@ function parseString(str){
  * @api public
  */
 
-exports.parse = function(str){
+exports.parse = function(str, del){
+  del = del && isdelim.test(del) ? del[0] : undefined;
   if (null == str || '' == str) return {};
   return 'object' == typeof str
-    ? parseObject(str)
-    : parseString(str);
+    ? parseObject(str, del)
+    : parseString(str, del);
 };
 
 /**

--- a/querystring.js
+++ b/querystring.js
@@ -18,10 +18,11 @@ exports.version = '0.4.2';
 var toString = Object.prototype.toString;
 
 /**
- * Cache non-integer test regexp.
+ * Cache non-integer and custom delimiter test regexp.
  */
 
-var isint = /^[0-9]+$/;
+var isint = /^[0-9]+$/
+  , isdelim = /^[^\?&#=\[\]]/;
 
 function promote(parent, key) {
   if (parent[key].length == 0) return parent[key] = {};
@@ -72,11 +73,28 @@ function parse(parts, parent, key, val) {
  * Merge parent key/val pair.
  */
 
-function merge(parent, key, val){
+function merge(parent, key, val, del){
   if (~key.indexOf(']')) {
     var parts = key.split('[')
       , len = parts.length
       , last = len - 1;
+    if (del) {
+        var keydel = ']' + del;
+        for ( var idx = 0; idx < parts.length; idx++ ) {
+            var part = parts[idx]
+              , args = [idx, 1]
+              , k = part.split(keydel, 2);
+            switch (true) {
+                case k.length > 1:
+                    args.push(k[0]);
+                    part = k[1];
+                case idx === 0:
+                    args = args.concat(part.split(del));
+                    idx += args.length - 3;
+                    parts.splice.apply(parts, args);
+            }
+        }
+    }
     parse(parts, parent, 'base', val);
     // optimize
   } else {
@@ -85,7 +103,11 @@ function merge(parent, key, val){
       for (var k in parent.base) t[k] = parent.base[k];
       parent.base = t;
     }
-    set(parent.base, key, val);
+    var parts = key.split(del);
+    if (parts.length > 1)
+        parse(parts, parent, 'base', val);
+    else
+        set(parent.base, key, val);
   }
 
   return parent;
@@ -95,10 +117,10 @@ function merge(parent, key, val){
  * Parse the given obj.
  */
 
-function parseObject(obj){
+function parseObject(obj, del){
   var ret = { base: {} };
   Object.keys(obj).forEach(function(name){
-    merge(ret, name, obj[name]);
+    merge(ret, name, obj[name], del);
   });
   return ret.base;
 }
@@ -107,7 +129,7 @@ function parseObject(obj){
  * Parse the given str.
  */
 
-function parseString(str){
+function parseString(str, del){
   return String(str)
     .split('&')
     .reduce(function(ret, pair){
@@ -126,7 +148,7 @@ function parseString(str){
       // ?foo
       if ('' == key) key = pair, val = '';
 
-      return merge(ret, key, val);
+      return merge(ret, key, val, del);
     }, { base: {} }).base;
 }
 
@@ -138,11 +160,12 @@ function parseString(str){
  * @api public
  */
 
-exports.parse = function(str){
+exports.parse = function(str, del){
+  del = del && isdelim.test(del) ? del[0] : undefined;
   if (null == str || '' == str) return {};
   return 'object' == typeof str
-    ? parseObject(str)
-    : parseString(str);
+    ? parseObject(str, del)
+    : parseString(str, del);
 };
 
 /**

--- a/test/parse.js
+++ b/test/parse.js
@@ -114,7 +114,7 @@ describe('qs.parse()', function(){
       .to.eql({ op: { '>=': '[1,2,3]' }});
 
     expect(qs.parse('op[>=]=[1,2,3]&op[=]=[[[[1]]]]'))
-          .to.eql({ op: { '>=': '[1,2,3]', '=': '[[[[1]]]]' }});
+      .to.eql({ op: { '>=': '[1,2,3]', '=': '[[[[1]]]]' }});
   })
 
   it('should support empty values', function(){
@@ -138,6 +138,61 @@ describe('qs.parse()', function(){
       .to.eql({ user: { name: 'tobi' }});
 
     expect(qs.parse({ 'user[name]': 'tobi', 'user[email][main]': 'tobi@lb.com' }))
+      .to.eql({ user: { name: 'tobi', email: { main: 'tobi@lb.com' } }});
+  })
+
+  it('should support custom delimiters', function(){
+    expect(qs.parse('foo.bar=rawr', '.'))
+      .to.eql({ foo: { bar: 'rawr' } });
+
+    expect(qs.parse('foo.bar=rawr&foo.rawr=bar', '.'))
+      .to.eql({ foo: { bar: 'rawr', rawr: 'bar' }});
+
+    expect(qs.parse('foo.bar=rawr&foo.bar=rawk', '.'))
+      .to.eql({ foo: { bar: ['rawr', 'rawk'] }});
+  })
+
+  it('should support mix and match', function() {
+    expect(qs.parse('foo.bar[0][]=rawr', '.'))
+      .to.eql({ foo: { bar: [['rawr']] }});
+
+    expect(qs.parse('foo.bar.fib[hello][world]=rawk', '.'))
+      .to.eql({ foo: { bar: { fib: { hello: { world: 'rawk' } }}}});
+
+    expect(qs.parse('foo[bar].rawr=fubar', '.'))
+      .to.eql({ foo: { bar: { rawr: 'fubar' } }});
+
+    expect(qs.parse('foo[bar].rawk.on=fubar', '.'))
+      .to.eql({ foo: { bar: { rawk: { on: 'fubar' } }}});
+
+    expect(qs.parse('foo[0].bar=rawr&foo[0].boo=rawk&foo[1].bar=bump', '.'))
+      .to.eql({ foo: [ { bar: 'rawr', boo: 'rawk' }, { bar: 'bump' } ]});
+
+    expect(qs.parse('foo[bar].rawk[on].boom=fubar', '.'))
+      .to.eql({ foo: { bar: { rawk: { on: { boom: 'fubar' } }}}});
+  })
+
+  it('should support delimiters in keys', function() {
+    expect(qs.parse('foo[rawk.on]=rawr', '.'))
+      .to.eql({ foo: { 'rawk.on': 'rawr' } });
+
+    expect(qs.parse('foo.bar[boom.shaka].lacka=bump', '.'))
+      .to.eql({ foo: { bar: { 'boom.shaka': { 'lacka': 'bump' } }}});
+  })
+
+  it('should support right-hand side delimiters', function() {
+    expect(qs.parse('foo.bar=boom.shaka.lacka', '.'))
+      .to.eql({ foo: { bar: 'boom.shaka.lacka' }});
+
+    expect(qs.parse('foo[boing]=shakala.kaaa', '.'))
+      .to.eql({ foo: { boing: 'shakala.kaaa' }});
+  })
+
+  it('should support semi-parsed delimited strings', function(){
+    expect(qs.parse({ 'user.name': 'tobi' }, '.'))
+      .to.eql({ user: { name: 'tobi' }});
+
+    expect(qs.parse({ 'user.name': 'tobi', 'user[email].main': 'tobi@lb.com' }, '.'))
       .to.eql({ user: { name: 'tobi', email: { main: 'tobi@lb.com' } }});
   })
 })


### PR DESCRIPTION
Implements GH-1.

This will allow one additional single character delimiter to be used in conjunction with the existing syntax, allowing support for querystrings such as:

```
foo.bar[0].boing[he.llo].world.rawr=rawk.txt
```

To be parsed correctly with the `.` delimiter as:

``` javascript
{ foo: { bar: [ { boing: { 'he.llo': { world: { rawr: 'rawk.txt' } } } } ] } }
```

Found this behavior mentioned on mcavage/node-restify#94 which lead me to GH-1, figured I'd give it a whirl; feedback welcome.
