### PR TITLE
Added Custom Delimiter Support

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -23,6 +23,33 @@ var toString = Object.prototype.toString;
 
 var isint = /^[0-9]+$/;
 
+/**
+ * Delimiter test regexp.
+ */
+
+var isdelim = /^[^\?&#=\[\]]$/;
+
+function delimit(parts, del) {
+    if ('string' == typeof parts) return parts.split(del);
+    if (!Array.isArray(parts)) return parts;
+    var keydel = ']' + del;
+    for ( var idx = 0; idx < parts.length; idx++ ) {
+        var part = parts[idx]
+          , args = [idx, 1]
+          , k = part.split(keydel, 2);
+        switch (true) {
+            case k.length > 1:
+                args.push(k[0]);
+                part = k[1];
+            case idx === 0:
+                args = args.concat(part.split(del));
+                idx += args.length - 3;
+                parts.splice.apply(parts, args);
+        }
+    }
+    return parts;
+}
+
 function promote(parent, key) {
   if (parent[key].length == 0) return parent[key] = {};
   var t = {};
@@ -72,11 +99,12 @@ function parse(parts, parent, key, val) {
  * Merge parent key/val pair.
  */
 
-function merge(parent, key, val){
+function merge(parent, key, val, options){
   if (~key.indexOf(']')) {
     var parts = key.split('[')
       , len = parts.length
       , last = len - 1;
+    if (options.delimiter) parts = delimit(parts, options.delimiter);
     parse(parts, parent, 'base', val);
     // optimize
   } else {
@@ -85,7 +113,11 @@ function merge(parent, key, val){
       for (var k in parent.base) t[k] = parent.base[k];
       parent.base = t;
     }
-    set(parent.base, key, val);
+    var parts = delimit(key, options.delimiter);
+    if (parts.length > 1)
+        parse(parts, parent, 'base', val);
+    else
+        set(parent.base, key, val);
   }
 
   return parent;
@@ -95,10 +127,10 @@ function merge(parent, key, val){
  * Parse the given obj.
  */
 
-function parseObject(obj){
+function parseObject(obj, options){
   var ret = { base: {} };
   Object.keys(obj).forEach(function(name){
-    merge(ret, name, obj[name]);
+    merge(ret, name, obj[name], options);
   });
   return ret.base;
 }
@@ -107,7 +139,7 @@ function parseObject(obj){
  * Parse the given str.
  */
 
-function parseString(str){
+function parseString(str, options){
   return String(str)
     .split('&')
     .reduce(function(ret, pair){
@@ -126,23 +158,30 @@ function parseString(str){
       // ?foo
       if ('' == key) key = pair, val = '';
 
-      return merge(ret, key, val);
+      return merge(ret, key, val, options);
     }, { base: {} }).base;
 }
 
 /**
  * Parse the given query `str` or `obj`, returning an object.
  *
+ * Options:
+ *
+ *  - `delimiter` suppilied character will be treated as a dot operator in keys
+ *
  * @param {String} str | {Object} obj
+ * @param {Object} options
  * @return {Object}
  * @api public
  */
 
-exports.parse = function(str){
+exports.parse = function(str, options){
+  options = options || {};
+  if (options.delimiter && !isdelim.test(options.delimiter)) delete options.delimiter;
   if (null == str || '' == str) return {};
   return 'object' == typeof str
-    ? parseObject(str)
-    : parseString(str);
+    ? parseObject(str, options)
+    : parseString(str, options);
 };
 
 /**

--- a/querystring.js
+++ b/querystring.js
@@ -23,6 +23,33 @@ var toString = Object.prototype.toString;
 
 var isint = /^[0-9]+$/;
 
+/**
+ * Delimiter test regexp.
+ */
+
+var isdelim = /^[^\?&#=\[\]]$/;
+
+function delimit(parts, del) {
+    if ('string' == typeof parts) return parts.split(del);
+    if (!Array.isArray(parts)) return parts;
+    var keydel = ']' + del;
+    for ( var idx = 0; idx < parts.length; idx++ ) {
+        var part = parts[idx]
+          , args = [idx, 1]
+          , k = part.split(keydel, 2);
+        switch (true) {
+            case k.length > 1:
+                args.push(k[0]);
+                part = k[1];
+            case idx === 0:
+                args = args.concat(part.split(del));
+                idx += args.length - 3;
+                parts.splice.apply(parts, args);
+        }
+    }
+    return parts;
+}
+
 function promote(parent, key) {
   if (parent[key].length == 0) return parent[key] = {};
   var t = {};
@@ -72,11 +99,12 @@ function parse(parts, parent, key, val) {
  * Merge parent key/val pair.
  */
 
-function merge(parent, key, val){
+function merge(parent, key, val, options){
   if (~key.indexOf(']')) {
     var parts = key.split('[')
       , len = parts.length
       , last = len - 1;
+    if (options.delimiter) parts = delimit(parts, options.delimiter);
     parse(parts, parent, 'base', val);
     // optimize
   } else {
@@ -85,7 +113,11 @@ function merge(parent, key, val){
       for (var k in parent.base) t[k] = parent.base[k];
       parent.base = t;
     }
-    set(parent.base, key, val);
+    var parts = delimit(key, options.delimiter);
+    if (parts.length > 1)
+        parse(parts, parent, 'base', val);
+    else
+        set(parent.base, key, val);
   }
 
   return parent;
@@ -95,10 +127,10 @@ function merge(parent, key, val){
  * Parse the given obj.
  */
 
-function parseObject(obj){
+function parseObject(obj, options){
   var ret = { base: {} };
   Object.keys(obj).forEach(function(name){
-    merge(ret, name, obj[name]);
+    merge(ret, name, obj[name], options);
   });
   return ret.base;
 }
@@ -107,7 +139,7 @@ function parseObject(obj){
  * Parse the given str.
  */
 
-function parseString(str){
+function parseString(str, options){
   return String(str)
     .split('&')
     .reduce(function(ret, pair){
@@ -126,23 +158,30 @@ function parseString(str){
       // ?foo
       if ('' == key) key = pair, val = '';
 
-      return merge(ret, key, val);
+      return merge(ret, key, val, options);
     }, { base: {} }).base;
 }
 
 /**
  * Parse the given query `str` or `obj`, returning an object.
  *
+ * Options:
+ *
+ *  - `delimiter` suppilied character will be treated as a dot operator in keys
+ *
  * @param {String} str | {Object} obj
+ * @param {Object} options
  * @return {Object}
  * @api public
  */
 
-exports.parse = function(str){
+exports.parse = function(str, options){
+  options = options || {};
+  if (options.delimiter && !isdelim.test(options.delimiter)) delete options.delimiter;
   if (null == str || '' == str) return {};
   return 'object' == typeof str
-    ? parseObject(str)
-    : parseString(str);
+    ? parseObject(str, options)
+    : parseString(str, options);
 };
 
 /**

--- a/test/parse.js
+++ b/test/parse.js
@@ -140,4 +140,69 @@ describe('qs.parse()', function(){
     expect(qs.parse({ 'user[name]': 'tobi', 'user[email][main]': 'tobi@lb.com' }))
       .to.eql({ user: { name: 'tobi', email: { main: 'tobi@lb.com' } }});
   })
+
+  describe('when "delimiter" is used', function(){
+    function parse(str){
+      return qs.parse(str, { delimiter: '.' });
+    };
+
+    it('should support custom delimiters', function(){
+      expect(parse('foo.bar=rawr'))
+        .to.eql({ foo: { bar: 'rawr' } });
+
+      expect(parse('foo.bar=rawr&foo.rawr=bar'))
+        .to.eql({ foo: { bar: 'rawr', rawr: 'bar' }});
+
+      expect(parse('foo.bar=rawr&foo.bar=rawk'))
+        .to.eql({ foo: { bar: ['rawr', 'rawk'] }});
+    })
+
+    it('should support mix and match', function() {
+      expect(parse('foo.bar[0][]=rawr'))
+        .to.eql({ foo: { bar: [['rawr']] }});
+
+      expect(parse('foo.bar.fib[hello][world]=rawk'))
+        .to.eql({ foo: { bar: { fib: { hello: { world: 'rawk' } }}}});
+
+      expect(parse('foo[bar].rawr=fubar'))
+        .to.eql({ foo: { bar: { rawr: 'fubar' } }});
+
+      expect(parse('foo[bar].rawk.on=fubar'))
+        .to.eql({ foo: { bar: { rawk: { on: 'fubar' } }}});
+
+      expect(parse('foo[0].bar=rawr&foo[0].boo=rawk&foo[1].bar=bump'))
+        .to.eql({ foo: [ { bar: 'rawr', boo: 'rawk' }, { bar: 'bump' } ]});
+
+      expect(parse('foo[bar].rawk[on].boom=fubar'))
+        .to.eql({ foo: { bar: { rawk: { on: { boom: 'fubar' } }}}});
+    })
+
+    it('should support delimiters in keys', function() {
+      expect(parse('foo[rawk.on]=rawr'))
+        .to.eql({ foo: { 'rawk.on': 'rawr' } });
+
+      expect(parse('foo.bar[boom.shaka].lacka=bump'))
+        .to.eql({ foo: { bar: { 'boom.shaka': { 'lacka': 'bump' } }}});
+    })
+
+    it('should support right-hand side delimiters', function() {
+      expect(parse('foo.bar=boom.shaka.lacka'))
+        .to.eql({ foo: { bar: 'boom.shaka.lacka' }});
+
+      expect(parse('foo[boing]=shakala.kaaa'))
+        .to.eql({ foo: { boing: 'shakala.kaaa' }});
+    })
+
+    it('should support semi-parsed delimited strings', function(){
+      expect(parse({ 'user.name': 'tobi' }))
+        .to.eql({ user: { name: 'tobi' }});
+    })
+  })
+
+  describe('when "delimiter" is not used', function(){
+    it('should not parse delimiters', function(){
+      expect(qs.parse({ 'user.name': 'tobi' }))
+        .to.eql({ 'user.name': 'tobi' });
+    })
+  })
 })


### PR DESCRIPTION
Implements GH-1 - _this time taking style tips from the coerce branch_.

This will allow one additional single character delimiter to be used in conjunction with the existing syntax, allowing support for querystrings such as:

```
foo.bar[0].boing[he.llo].world.rawr=rawk.txt
```

To be parsed correctly with the `.` delimiter as:

``` javascript
{ foo: { bar: [ { boing: { 'he.llo': { world: { rawr: 'rawk.txt' } } } } ] } }
```

Found this behavior mentioned on mcavage/node-restify#94 which lead me to GH-1, figured I'd give it a whirl; feedback welcome.
