### PR TITLE
Make `make test` work on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ querystring.js: lib/head.js lib/querystring.js lib/tail.js
 	cat $^ > $@ 
 
 test:
-	@./node_modules/.bin/mocha \
+	@"./node_modules/.bin/mocha" \
 		--ui bdd
-
+		
 .PHONY: test


### PR DESCRIPTION
Quoting the filename avoids the following error on Windows:

> '.' is not recognized as an internal or external command,
> operable
> program or batch file.
> make: **\* [test] Error 1
