### PR TITLE
Fixed bug when nested POST variables contained excessive characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function parse(parts, parent, key, val) {
 
 function merge(parent, key, val){
   if (~key.indexOf(']')) {
-    var parts = key.split('[')
+    var parts = key.split(/[\[\]]/)
       , len = parts.length
       , last = len - 1;
     parse(parts, parent, 'base', val);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qs",
   "description": "querystring parser",
-  "version": "0.5.3",
+  "version": "0.5.3-1",
   "keywords": ["query string", "parser", "component"],
   "repository": {
     "type" : "git",


### PR DESCRIPTION
We faced a pity situation when the form

```
<form ...>
<input name="question[options[a]]" />
</form>
```

being submit returned the object

```
{
  question: {
    options: {
      'a]': 'the value'
    }
  }
}
```

Found the bug when excessive elements were merged into the object, fixed simply removing them from the parts array being merged.

**Note: this is a major-priority bugfix as it may break much functionality!**
