### PR TITLE
npmignore unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+test
+.travis.yml
+benchmark.js
+component.json
+examples.js
+History.md
+Makefile


### PR DESCRIPTION
No point in wasting bandwidth and space. This would make the module 0.4MB smaller.
