### PR TITLE
Fix possibility to create huge arrays of null objects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,27 @@ function merge(parent, key, val){
 }
 
 /**
+ * Compact sparse arrays
+ */
+
+function compact(obj) {
+  if ('object' != typeof obj) return obj;
+
+  if (isArray(obj)) {
+    var ret = [];
+    for (var i in obj) ret.push(obj[i]);
+    return ret;
+  }
+
+  for (var key in obj) {
+    obj[key] = compact(obj[key]);
+  }
+
+  return obj;
+}
+
+
+/**
  * Parse the given obj.
  */
 
@@ -150,7 +171,8 @@ function parseObject(obj){
   forEach(objectKeys(obj), function(name){
     merge(ret, name, obj[name]);
   });
-  return ret.base;
+
+  return compact(ret.base);
 }
 
 /**
@@ -158,7 +180,7 @@ function parseObject(obj){
  */
 
 function parseString(str){
-  return reduce(String(str).split('&'), function(ret, pair){
+  var ret = reduce(String(str).split('&'), function(ret, pair){
     var eql = indexOf(pair, '=')
       , brace = lastBraceInKey(pair)
       , key = pair.substr(0, brace || eql)
@@ -171,6 +193,8 @@ function parseString(str){
 
     return merge(ret, decode(key), decode(val));
   }, { base: createObject() }).base;
+
+  return compact(ret);
 }
 
 /**

--- a/test/parse.js
+++ b/test/parse.js
@@ -150,6 +150,12 @@ describe('qs.parse()', function(){
       .to.eql({ _r: '1' })
   })
 
+  it('should not create big arrays of null objects', function(){
+    var q = qs.parse('a[999999999]=1&a[2]=2');
+    expect(q['a'].length).to.eql(2);
+    expect(q).to.eql({ a: ['2', '1'] });
+  })
+
   if ('undefined' == typeof window) {
     it('should not be possible to access Object prototype', function() {
       qs.parse('constructor[prototype][bad]=bad');


### PR DESCRIPTION
This fixes a serious bug. Someone hitting an app with a param like `a[999999999]=1` could make a node process crash by running out memory very quickly.

Example:

``` javascript
var qs = require('qs');

console.log(qs.parse('a[999999999]=1'));
```
