### PR TITLE
Avoid infinite loop when a native prototype has an enumerable property

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
-
 /**
  * Object#toString() ref for stringify().
  */
 
 var toString = Object.prototype.toString;
+
+/**
+ * Object#hasOwnProperty ref
+ */
+
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * Array#indexOf shim.
@@ -172,7 +177,9 @@ function restoreProto(obj) {
   if (obj && 'object' != typeof obj) return obj;
 
   for (var key in obj) {
-    obj[key] = restoreProto(obj[key]);
+    if (hasOwnProperty.call(obj, key)) {
+      obj[key] = restoreProto(obj[key]);
+    }
   }
 
   obj.__proto__ = Object.prototype;

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,3 @@
-
 if (require.register) {
   var qs = require('querystring');
 } else {
@@ -165,5 +164,10 @@ describe('qs.parse()', function(){
       qs.parse('bad[constructor][prototype][bad]=bad');
       expect(Object.prototype.bad).to.be(undefined);
     });
+    
+    it('should not throw when a native prototype has an enumerable property', function() {
+      Object.prototype.crash = '';
+      expect(qs.parse.bind(null, 'test')).to.not.throwException();
+    })
   }
 })


### PR DESCRIPTION
fixes visionmedia/express#1606
