### PR TITLE
Use hasOwnProperty when iterating over Array

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,11 @@ var isint = /^[0-9]+$/;
 function promote(parent, key) {
   if (parent[key].length == 0) return parent[key] = createObject();
   var t = createObject();
-  for (var i in parent[key]) t[i] = parent[key][i];
+  for (var i in parent[key]) {
+    if (hasOwnProperty.call(parent[key], i)) {
+      t[i] = parent[key][i];
+    }
+  }
   parent[key] = t;
   return t;
 }
@@ -155,7 +159,13 @@ function compact(obj) {
 
   if (isArray(obj)) {
     var ret = [];
-    for (var i in obj) ret.push(obj[i]);
+
+    for (var i in obj) {
+      if (hasOwnProperty.call(obj, i)) {
+        ret.push(obj[i]);
+      }
+    }
+
     return ret;
   }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -5,6 +5,8 @@ if (require.register) {
     , expect = require('expect.js');
 }
 
+Array.prototype.dummy = function () {}; // is should not be affected by Array.prototype
+
 describe('qs.parse()', function(){
   it('should support the basics', function(){
     qs.parse('foo=bar').hasOwnProperty('foo');


### PR DESCRIPTION
This fixes the issue from issue #65. In the tests, I added a dummy property to `Array.prototype` so the issue shows up in the tests. I then added `hasOwnProperty` checks to two `for ... in` loops that loop over arrays, which fixes the issue.
