### PR TITLE
Arrays need the object prototype too. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ function compact(obj) {
 
     for (var i in obj) {
       if (hasOwnProperty.call(obj, i)) {
-        ret.push(obj[i]);
+        ret.push(restoreProto(obj[i]));
       }
     }
 
@@ -183,10 +183,7 @@ function compact(obj) {
 
 function restoreProto(obj) {
   if (!Object.create) return obj;
-  if (isArray(obj)) {
-    obj.__proto__ = Object.prototype;
-    return obj;
-  }
+  if (isArray(obj)) return obj;
   if (obj && 'object' != typeof obj) return obj;
 
   for (var key in obj) {

--- a/index.js
+++ b/index.js
@@ -183,7 +183,10 @@ function compact(obj) {
 
 function restoreProto(obj) {
   if (!Object.create) return obj;
-  if (isArray(obj)) return obj;
+  if (isArray(obj)) {
+    obj.__proto__ = Object.prototype;
+    return obj;
+  }
   if (obj && 'object' != typeof obj) return obj;
 
   for (var key in obj) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -105,6 +105,10 @@ describe('qs.parse()', function(){
     expect(qs.parse('foo[base64]=RAWR')).to.eql({ foo: { base64: 'RAWR' }});
     expect(qs.parse('foo[64base]=RAWR')).to.eql({ foo: { '64base': 'RAWR' }});
   })
+	
+  it('should support toString() with an array of objects', function(){
+	    expect(qs.parse('foo[0][bar]=baz&foo[1][bat]=boo').foo.toString()).to.eql('[object Object],[object Object]');
+  })	
 
   it('should expand to an array when dupliate keys are present', function(){
     expect(qs.parse('items=bar&items=baz&items=raz'))


### PR DESCRIPTION
Found that the array's object prototype was missing and caused a "Cannot convert object to primitive value" type error when trying to use arr.toString() or isNaN(arr). 

Came about this when trying to evaluate arrays in a querystring after attempting and upgrade of express v.3.2.0 to v3.2.5.

Cheers.
