### PR TITLE
stringify with nested objects and null values does not work correctly

### DIFF
--- a/test/stringify.js
+++ b/test/stringify.js
@@ -46,7 +46,9 @@ var str_identities = {
     { str: 'x[y][0][z]=1&x[y][0][v][w]=2', obj: {'x' : {'y' : [{'z' : '1', 'v' : {'w' : '2'}}]}}},
     { str: 'x[y][0][z]=1&x[y][1][z]=2', obj: {'x' : {'y' : [{'z' : '1'}, {'z' : '2'}]}}},
     { str: 'x[y][0][z]=1&x[y][0][w]=a&x[y][1][z]=2&x[y][1][w]=3', obj: {'x' : {'y' : [{'z' : '1', 'w' : 'a'}, {'z' : '2', 'w' : '3'}]}}},
-    { str: 'user[name][first]=tj&user[name][last]=holowaychuk', obj: { user: { name: { first: 'tj', last: 'holowaychuk' }}}}
+    { str: 'user[name][first]=tj&user[name][last]=holowaychuk', obj: { user: { name: { first: 'tj', last: 'holowaychuk' }}}},
+    { str: 'user[name][first]=&user[name][last]=holowaychuk', obj: { user: { name: { first: '', last: 'holowaychuk' }}}},
+    { str: 'user[name][first]=&user[name][last]=holowaychuk', obj: { user: { name: { first: null, last: 'holowaychuk' }}}}
   ],
   'errors': [
     { obj: 'foo=bar',     message: 'stringify expects an object' },


### PR DESCRIPTION
qs generates incorrect querystring when nested object contains null or undefined values :

``` javascript
obj = {foo: 1, nested: { bar: null, qux: true } }
qs.stringify(obj) // => foo=1&bar=&nested[qux]=true
```

See that bar parameter is not nested :( 

I've attached failing test for this scenario.
