### PR TITLE
Skip prototype properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ var isArray = Array.isArray || function(arr) {
 
 var objectKeys = Object.keys || function(obj) {
   var ret = [];
-  for (var key in obj) ret.push(key);
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      ret.push(key);
+    }
+  }
   return ret;
 };
 


### PR DESCRIPTION
To be a proper object-keys shim, it has to only iterate over own properties.

Would you be OK adding a dependency, `object-keys`? It's a well-tested Object.keys shim.
