### PR TITLE
make forEach and reduce shims slightly more compliant

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ var objectKeys = Object.keys || function(obj) {
 var forEach = typeof Array.prototype.forEach === 'function'
   ? function(arr, fn) { return arr.forEach(fn); }
   : function(arr, fn) {
-      for (var i = 0; i < arr.length; i++) fn(arr[i]);
+      for (var i = 0; i < arr.length; i++) fn(arr[i], i, arr);
     };
 
 /**
@@ -76,7 +76,12 @@ var forEach = typeof Array.prototype.forEach === 'function'
 var reduce = function(arr, fn, initial) {
   if (typeof arr.reduce === 'function') return arr.reduce(fn, initial);
   var res = initial;
-  for (var i = 0; i < arr.length; i++) res = fn(res, arr[i]);
+  var i = 0;
+  if (!res) {
+    res = arr[0];
+    i = 1;
+  }
+  for (i; i < arr.length; i++) res = fn(res, arr[i], i, arr);
   return res;
 };
 


### PR DESCRIPTION
ES5 array iterators take 3 args: value, index, and array.

I haven't yet added support for the 4th optional "context" arg.

In addition, if the initial value is not supplied to `reduce`, the first value from the array is used, and iteration begins with the second value.
