### PR TITLE
Make `make test` work on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-
 test:
-	@./node_modules/.bin/mocha \
+	@"./node_modules/.bin/mocha" \
 		--ui bdd
 
 .PHONY: test


### PR DESCRIPTION
Quoting the filename avoids the following error on Windows:

> '.' is not recognized as an internal or external command,
> operable
> program or batch file.
> make: **\* [test] Error 1
