### PR TITLE
readme: add travis build badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# node-querystring
+# node-querystring [![Build Status](https://travis-ci.org/visionmedia/node-querystring.png?branch=master)](https://travis-ci.org/visionmedia/node-querystring)
 
   query string parser for node and the browser supporting nesting, as it was removed from `0.3.x`, so this library provides the previous and commonly desired behaviour (and twice as fast). Used by [express](http://expressjs.com), [connect](http://senchalabs.github.com/connect) and others.
 


### PR DESCRIPTION
This adds [![Build Status](https://travis-ci.org/visionmedia/node-querystring.png?branch=master)](https://travis-ci.org/visionmedia/node-querystring) to the readme.
Unnecessary or stylish?

[I find it quite posh.](http://gifsound.com/?gif=i.imgur.com/zX9u568.gif&v=6t28COxEp2k&s=26)

[![Posh cat](http://i.imgur.com/zX9u568.gif)](http://gifsound.com/?gif=i.imgur.com/zX9u568.gif&v=6t28COxEp2k&s=26)
