### PR TITLE
Replace getOwnPropertyDescriptor with hasOwnProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,10 +86,10 @@ function promote(parent, key) {
 
 function parse(parts, parent, key, val) {
   var part = parts.shift();
-  
+
   // illegal
-  if (Object.getOwnPropertyDescriptor(Object.prototype, key)) return;
-  
+  if (hasOwnProperty.call(Object.prototype, key)) return;
+
   // end
   if (!part) {
     if (isArray(parent[key])) {
@@ -319,7 +319,7 @@ function stringifyObject(obj, prefix) {
 
 function set(obj, key, val) {
   var v = obj[key];
-  if (Object.getOwnPropertyDescriptor(Object.prototype, key)) return;
+  if (hasOwnProperty.call(Object.prototype, key)) return;
   if (undefined === v) {
     obj[key] = val;
   } else if (isArray(v)) {


### PR DESCRIPTION
This is the only thing preventing queryString from being IE8 compatible. And for our purposes we may as well use hasOwnProperty anyway, we're not using the getOwnPropertyDescriptor result.
