### PR TITLE
Support for semicolon separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,11 +219,12 @@ function parseString(str, supportSemicolon){
  * @api public
  */
 
-exports.parse = function(str, supportSemicolon){
+exports.parse = function(str, options){
   if (null == str || '' == str) return {};
+  options = options || {};
   return 'object' == typeof str
     ? parseObject(str)
-    : parseString(str, supportSemicolon);
+    : parseString(str, options.supportSemicolon);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -192,9 +192,8 @@ function parseObject(obj){
  * Parse the given str.
  */
 
-function parseString(str, supportSemicolon){
-  var delim = supportSemicolon ? /[&;]/ : '&';
-  var ret = reduce(String(str).split(delim), function(ret, pair){
+function parseString(str, options){
+  var ret = reduce(String(str).split(options.separator), function(ret, pair){
     var eql = indexOf(pair, '=')
       , brace = lastBraceInKey(pair)
       , key = pair.substr(0, brace || eql)
@@ -222,9 +221,10 @@ function parseString(str, supportSemicolon){
 exports.parse = function(str, options){
   if (null == str || '' == str) return {};
   options = options || {};
+  options.separator = options.separator || '&';
   return 'object' == typeof str
     ? parseObject(str)
-    : parseString(str, options.supportSemicolon);
+    : parseString(str, options);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ function parseObject(obj){
  */
 
 function parseString(str){
-  var ret = reduce(String(str).split('&'), function(ret, pair){
+  var ret = reduce(String(str).split(/[&;]/), function(ret, pair){
     var eql = indexOf(pair, '=')
       , brace = lastBraceInKey(pair)
       , key = pair.substr(0, brace || eql)

--- a/index.js
+++ b/index.js
@@ -192,8 +192,9 @@ function parseObject(obj){
  * Parse the given str.
  */
 
-function parseString(str){
-  var ret = reduce(String(str).split(/[&;]/), function(ret, pair){
+function parseString(str, supportSemicolon){
+  var delim = supportSemicolon ? /[&;]/ : '&';
+  var ret = reduce(String(str).split(delim), function(ret, pair){
     var eql = indexOf(pair, '=')
       , brace = lastBraceInKey(pair)
       , key = pair.substr(0, brace || eql)
@@ -218,11 +219,11 @@ function parseString(str){
  * @api public
  */
 
-exports.parse = function(str){
+exports.parse = function(str, supportSemicolon){
   if (null == str || '' == str) return {};
   return 'object' == typeof str
     ? parseObject(str)
-    : parseString(str);
+    : parseString(str, supportSemicolon);
 };
 
 /**

--- a/test/parse.js
+++ b/test/parse.js
@@ -56,8 +56,8 @@ describe('qs.parse()', function(){
   it('should support semicolon separators', function(){
     expect(qs.parse('a=1;b=2')).to.eql({a:'1;b=2'});
     expect(qs.parse('a=1;b=2&c=3')).to.eql({a:'1;b=2',c:'3'});
-    expect(qs.parse('a=1;b=2', true)).to.eql({a:'1',b:'2'});
-    expect(qs.parse('a=1;b=2&c=3', true)).to.eql({a:'1',b:'2',c:'3'});
+    expect(qs.parse('a=1;b=2', { supportSemicolon: true })).to.eql({a:'1',b:'2'});
+    expect(qs.parse('a=1;b=2&c=3', { supportSemicolon: true })).to.eql({a:'1',b:'2',c:'3'});
   });
 
   it('should support encoded = signs', function(){

--- a/test/parse.js
+++ b/test/parse.js
@@ -56,8 +56,12 @@ describe('qs.parse()', function(){
   it('should support semicolon separators', function(){
     expect(qs.parse('a=1;b=2')).to.eql({a:'1;b=2'});
     expect(qs.parse('a=1;b=2&c=3')).to.eql({a:'1;b=2',c:'3'});
-    expect(qs.parse('a=1;b=2', { supportSemicolon: true })).to.eql({a:'1',b:'2'});
-    expect(qs.parse('a=1;b=2&c=3', { supportSemicolon: true })).to.eql({a:'1',b:'2',c:'3'});
+    expect(qs.parse('a=1;b=2', { separator: ';' })).to.eql({a:'1',b:'2'});
+    expect(qs.parse('a=1;b=2&c=3', { separator: ';' })).to.eql({a:'1',b:'2&c=3'});
+  });
+
+  it('should support regex separators', function(){
+    expect(qs.parse('a=1;b=2&c=3', { separator: /[;&]/ })).to.eql({a:'1',b:'2',c:'3'});
   });
 
   it('should support encoded = signs', function(){

--- a/test/parse.js
+++ b/test/parse.js
@@ -51,12 +51,13 @@ describe('qs.parse()', function(){
         , chs: '250x100'
         , chl: 'Hello|World'
       });
-
   })
 
   it('should support semicolon separators', function(){
-    expect(qs.parse('a=1;b=2')).to.eql({a:'1',b:'2'});
-    expect(qs.parse('a=1;b=2&c=3')).to.eql({a:'1',b:'2',c:'3'});
+    expect(qs.parse('a=1;b=2')).to.eql({a:'1;b=2'});
+    expect(qs.parse('a=1;b=2&c=3')).to.eql({a:'1;b=2',c:'3'});
+    expect(qs.parse('a=1;b=2', true)).to.eql({a:'1',b:'2'});
+    expect(qs.parse('a=1;b=2&c=3', true)).to.eql({a:'1',b:'2',c:'3'});
   });
 
   it('should support encoded = signs', function(){

--- a/test/parse.js
+++ b/test/parse.js
@@ -51,7 +51,13 @@ describe('qs.parse()', function(){
         , chs: '250x100'
         , chl: 'Hello|World'
       });
+
   })
+
+  it('should support semicolon separators', function(){
+    expect(qs.parse('a=1;b=2')).to.eql({a:'1',b:'2'});
+    expect(qs.parse('a=1;b=2&c=3')).to.eql({a:'1',b:'2',c:'3'});
+  });
 
   it('should support encoded = signs', function(){
     expect(qs.parse('he%3Dllo=th%3Dere'))
@@ -176,5 +182,5 @@ describe('qs.parse()', function(){
   it('should not throw when a native prototype has an enumerable property', function() {
     Object.prototype.crash = '';
     expect(qs.parse.bind(null, 'test')).to.not.throwException();
-  })
+  });
 })


### PR DESCRIPTION
As far as I can tell [W3C encourages server implementors to support the use of semicolons](http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2) as a query separator.
