### PR TITLE
add optional separator support to stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,11 +235,11 @@ exports.parse = function(str, options){
  * @api public
  */
 
-var stringify = exports.stringify = function(obj, prefix) {
+var stringify = exports.stringify = function(obj, prefix, separator) {
   if (isArray(obj)) {
-    return stringifyArray(obj, prefix);
+    return stringifyArray(obj, prefix, separator);
   } else if ('[object Object]' == toString.call(obj)) {
-    return stringifyObject(obj, prefix);
+    return stringifyObject(obj, prefix, separator);
   } else if ('string' == typeof obj) {
     return stringifyString(obj, prefix);
   } else {
@@ -270,13 +270,13 @@ function stringifyString(str, prefix) {
  * @api private
  */
 
-function stringifyArray(arr, prefix) {
+function stringifyArray(arr, prefix, separator) {
   var ret = [];
   if (!prefix) throw new TypeError('stringify expects an object');
   for (var i = 0; i < arr.length; i++) {
     ret.push(stringify(arr[i], prefix + '[' + i + ']'));
   }
-  return ret.join('&');
+  return ret.join(separator || '&');
 }
 
 /**
@@ -288,7 +288,7 @@ function stringifyArray(arr, prefix) {
  * @api private
  */
 
-function stringifyObject(obj, prefix) {
+function stringifyObject(obj, prefix, separator) {
   var ret = []
     , keys = objectKeys(obj)
     , key;
@@ -305,7 +305,7 @@ function stringifyObject(obj, prefix) {
     }
   }
 
-  return ret.join('&');
+  return ret.join(separator || '&');
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -235,15 +235,21 @@ exports.parse = function(str, options){
  * @api public
  */
 
-var stringify = exports.stringify = function(obj, prefix, separator) {
+var stringify = exports.stringify = function(obj, options) {
+  if ('string' === typeof options) {
+    options = {prefix: options};
+  }
+
+  options || (options = {});
+
   if (isArray(obj)) {
-    return stringifyArray(obj, prefix, separator);
+    return stringifyArray(obj, options);
   } else if ('[object Object]' == toString.call(obj)) {
-    return stringifyObject(obj, prefix, separator);
+    return stringifyObject(obj, options);
   } else if ('string' == typeof obj) {
-    return stringifyString(obj, prefix);
+    return stringifyString(obj, options.prefix);
   } else {
-    return prefix + '=' + encodeURIComponent(String(obj));
+    return options.prefix + '=' + encodeURIComponent(String(obj));
   }
 };
 
@@ -270,13 +276,16 @@ function stringifyString(str, prefix) {
  * @api private
  */
 
-function stringifyArray(arr, prefix, separator) {
+function stringifyArray(arr, options) {
   var ret = [];
-  if (!prefix) throw new TypeError('stringify expects an object');
+  if (!options.prefix) throw new TypeError('stringify expects an object');
   for (var i = 0; i < arr.length; i++) {
-    ret.push(stringify(arr[i], prefix + '[' + i + ']'));
+    ret.push(stringify(arr[i], {
+      prefix: options.prefix + '[' + i + ']',
+      separator: options.separator
+    }));
   }
-  return ret.join(separator || '&');
+  return ret.join(options.separator || '&');
 }
 
 /**
@@ -288,7 +297,7 @@ function stringifyArray(arr, prefix, separator) {
  * @api private
  */
 
-function stringifyObject(obj, prefix, separator) {
+function stringifyObject(obj, options) {
   var ret = []
     , keys = objectKeys(obj)
     , key;
@@ -299,13 +308,16 @@ function stringifyObject(obj, prefix, separator) {
     if (null == obj[key]) {
       ret.push(encodeURIComponent(key) + '=');
     } else {
-      ret.push(stringify(obj[key], prefix
-        ? prefix + '[' + encodeURIComponent(key) + ']'
-        : encodeURIComponent(key)));
+      ret.push(stringify(obj[key], {
+        prefix: options.prefix
+        ? options.prefix + '[' + encodeURIComponent(key) + ']'
+        : encodeURIComponent(key),
+        separator: options.separator
+      }));
     }
   }
 
-  return ret.join(separator || '&');
+  return ret.join(options.separator || '&');
 }
 
 /**

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -45,7 +45,7 @@ describe('qs.stringify', function(){
 		});
 
     it('should stringify with the given separator', function () {
-      expect(qs.stringify({ foo: 'bar', baz: 'raz', raz: ';' }, null, ';')).to.eql('foo=bar;baz=raz;raz=%3B');
+      expect(qs.stringify({ foo: 'bar', baz: 'raz', raz: ';' }, {prefix: 't', separator: ';'})).to.eql('t[foo]=bar;t[baz]=raz;t[raz]=%3B');
     });
   });
   
@@ -184,6 +184,12 @@ describe('qs.stringify', function(){
      var str = 'user[name][first]=tj&user[name][last]=holowaychuk';
      var obj =  { user: { name: { first: 'tj', last: 'holowaychuk' }}};
      expect(qs.stringify(obj)).to.eql(str); 
+    });
+
+    it('should work with an optional separator', function(){
+     var str = 'user[name][first]=onur;user[name][last]=gunduz';
+     var obj =  { user: { name: { first: 'onur', last: 'gunduz' }}};
+     expect(qs.stringify(obj, {separator: ';' })).to.eql(str); 
     });
 	});
 	

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -43,6 +43,10 @@ describe('qs.stringify', function(){
 		it('should strigify two empty values to not undefined', function() {
 		  expect(qs.stringify({ foo: 'bar', baz: '', raz: '' })).to.eql('foo=bar&baz=&raz='); 
 		});
+
+    it('should stringify with the given separator', function () {
+      expect(qs.stringify({ foo: 'bar', baz: 'raz', raz: ';' }, null, ';')).to.eql('foo=bar;baz=raz;raz=%3B');
+    });
   });
   
   describe('escaping', function(){
@@ -151,7 +155,6 @@ describe('qs.stringify', function(){
 			var obj =  {'x' : {'y' : [{'z' : '1', 'w' : '2'}]}};
 			expect(qs.stringify(obj)).to.eql(str); 
 		});
-		
 		
 		it('should work for object, array, object nesting', function(){
      var str = 'x[y][0][v][w]=1';


### PR DESCRIPTION
``` js
stringify({foo:1,bar:2}, null, ';'); // foo=1;bar=2
```
