### PR TITLE
convert string to array ie7 workarround

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 var indexOf = typeof Array.prototype.indexOf === 'function'
   ? function(arr, el) { return arr.indexOf(el); }
   : function(arr, el) {
+      if (typeof arr == 'string' && typeof "a"[0] == 'undefined') {
+        arr = arr.split('');
+      }
       for (var i = 0; i < arr.length; i++) {
         if (arr[i] === el) return i;
       }


### PR DESCRIPTION
This is a workaround for IE7 where strings can't be used as arrays directly.

Update pull request #80
