### PR TITLE
Make sure nesting arrays are compacted to avoid memory overflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,9 @@ function compact(obj) {
 
     for (var i in obj) {
       if (hasOwnProperty.call(obj, i)) {
-        ret.push(obj[i]);
+        // We need to compact the nesting array too
+        // See https://github.com/visionmedia/node-querystring/issues/104
+        ret.push(compact(obj[i]));
       }
     }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -170,6 +170,13 @@ describe('qs.parse()', function(){
     expect(q['a'].length).to.eql(2);
     expect(q).to.eql({ a: ['2', '1'] });
   })
+
+  it('should not create big nesting arrays of null objects', function () {
+    var q = qs.parse('a[0][999999999]=1');
+    console.log(q.a[0]);
+    expect(q['a'].length).to.eql(1);
+    expect(q['a'][0]).to.eql(['1']);
+  })
   
   it('should not be able to override prototypes', function(){
     var obj = qs.parse('toString=bad&bad[toString]=bad&constructor=bad');


### PR DESCRIPTION
The PR will fix https://github.com/visionmedia/node-querystring/issues/104 in a way that is consistent with the top level array compaction.

Please note that https://github.com/visionmedia/node-querystring/issues/104 is a serious security concern as malicious input string such as `foo[0][100000000]` will crash the node process.
